### PR TITLE
Kafka to Hoodie support

### DIFF
--- a/marmaray/src/main/java/com/uber/marmaray/common/configuration/HoodieConfiguration.java
+++ b/marmaray/src/main/java/com/uber/marmaray/common/configuration/HoodieConfiguration.java
@@ -65,6 +65,16 @@ public class HoodieConfiguration implements Serializable {
      * Schema for Hoodie dataset
      */
     public static final String HOODIE_AVRO_SCHEMA = HOODIE_COMMON_PROPERTY_PREFIX + "schema";
+
+    /**
+     * Record Key for Hoodie dataset
+     */
+    public static final String HOODIE_RECORD_KEY = HOODIE_COMMON_PROPERTY_PREFIX + "record_key";
+
+    /**
+     * Partition path for Hoodie dataset
+     */
+    public static final String HOODIE_PARTITION_PATH = HOODIE_COMMON_PROPERTY_PREFIX + "partition_path";
     /**
      * Flag to control whether it should combine before insert
      */
@@ -248,6 +258,20 @@ public class HoodieConfiguration implements Serializable {
      */
     public String getTableName() {
         return this.getConf().getProperty(getTablePropertyKey(HOODIE_TABLE_NAME, this.tableKey)).get();
+    }
+
+    /**
+     * @return hoodie record key.
+     */
+    public Optional<String> getHoodieRecordKey() {
+        return this.conf.getProperty(getTablePropertyKey(HOODIE_RECORD_KEY, this.tableKey));
+    }
+
+    /**
+     * @return hoodie partition path.
+     */
+    public Optional<String> getHoodiePartitionPath() {
+        return this.conf.getProperty(getTablePropertyKey(HOODIE_PARTITION_PATH, this.tableKey));
     }
 
     /**
@@ -489,6 +513,16 @@ public class HoodieConfiguration implements Serializable {
 
         public Builder withBasePath(@NotEmpty final String basePath) {
             this.conf.setProperty(getTablePropertyKey(HOODIE_BASE_PATH, this.tableKey), basePath);
+            return this;
+        }
+
+        public Builder withRecordKey(@NotEmpty final String recordKey) {
+            this.conf.setProperty(getTablePropertyKey(HOODIE_RECORD_KEY, this.tableKey), recordKey);
+            return this;
+        }
+
+        public Builder withPartitionPath(@NotEmpty final String partitionPath) {
+            this.conf.setProperty(getTablePropertyKey(HOODIE_PARTITION_PATH, this.tableKey), partitionPath);
             return this;
         }
 

--- a/marmaray/src/main/java/com/uber/marmaray/common/configuration/HoodieConfiguration.java
+++ b/marmaray/src/main/java/com/uber/marmaray/common/configuration/HoodieConfiguration.java
@@ -27,6 +27,7 @@ import com.uber.hoodie.config.HoodieStorageConfig;
 import com.uber.hoodie.config.HoodieWriteConfig;
 import com.uber.marmaray.common.exceptions.JobRuntimeException;
 import com.uber.marmaray.common.exceptions.MissingPropertyException;
+import com.uber.marmaray.common.sinks.hoodie.HoodieSink;
 import com.uber.marmaray.utilities.ConfigUtil;
 import com.uber.marmaray.utilities.StringTypes;
 import lombok.Getter;
@@ -75,6 +76,12 @@ public class HoodieConfiguration implements Serializable {
      * Partition path for Hoodie dataset
      */
     public static final String HOODIE_PARTITION_PATH = HOODIE_COMMON_PROPERTY_PREFIX + "partition_path";
+
+    /**
+     * Partition path for Hoodie dataset
+     */
+    public static final String HOODIE_SINK_OP = HOODIE_COMMON_PROPERTY_PREFIX + "sink_op";
+
     /**
      * Flag to control whether it should combine before insert
      */
@@ -272,6 +279,17 @@ public class HoodieConfiguration implements Serializable {
      */
     public Optional<String> getHoodiePartitionPath() {
         return this.conf.getProperty(getTablePropertyKey(HOODIE_PARTITION_PATH, this.tableKey));
+    }
+
+    /**
+     * @return hoodie sink operation
+     */
+    public HoodieSink.HoodieSinkOp getHoodieSinkOp() {
+        Optional<String> sinkOp = this.conf.getProperty(getTablePropertyKey(HOODIE_SINK_OP, this.tableKey));
+        if (sinkOp.isPresent()) {
+            return HoodieSink.HoodieSinkOp.valueOf(sinkOp.get().toUpperCase());
+        }
+        return HoodieSink.HoodieSinkOp.BULK_INSERT;
     }
 
     /**
@@ -528,6 +546,11 @@ public class HoodieConfiguration implements Serializable {
 
         public Builder withSchema(@NotEmpty final String schema) {
             this.conf.setProperty(getTablePropertyKey(HOODIE_AVRO_SCHEMA, this.tableKey), schema);
+            return this;
+        }
+
+        public Builder withSinkOp(@NotEmpty final String sinkOp) {
+            this.conf.setProperty(getTablePropertyKey(HOODIE_SINK_OP, this.tableKey), sinkOp);
             return this;
         }
 

--- a/marmaray/src/main/java/com/uber/marmaray/common/converters/data/DummyHoodieSinkDataConverter.java
+++ b/marmaray/src/main/java/com/uber/marmaray/common/converters/data/DummyHoodieSinkDataConverter.java
@@ -19,6 +19,7 @@ package com.uber.marmaray.common.converters.data;
 
 import com.uber.marmaray.common.AvroPayload;
 import com.uber.marmaray.common.configuration.Configuration;
+import com.uber.marmaray.common.configuration.HoodieConfiguration;
 import com.uber.marmaray.utilities.ErrorExtractor;
 
 import lombok.NonNull;
@@ -29,7 +30,9 @@ import lombok.NonNull;
  */
 public class DummyHoodieSinkDataConverter extends HoodieSinkDataConverter {
     public DummyHoodieSinkDataConverter() {
-        super(new Configuration(), new ErrorExtractor());
+
+        super(new Configuration(), new ErrorExtractor(), HoodieConfiguration.newBuilder(new Configuration(),
+                "test").build());
     }
 
     @Override

--- a/marmaray/src/main/java/com/uber/marmaray/common/converters/data/HoodieSinkDataConverter.java
+++ b/marmaray/src/main/java/com/uber/marmaray/common/converters/data/HoodieSinkDataConverter.java
@@ -59,7 +59,8 @@ public class HoodieSinkDataConverter extends SinkDataConverter<Schema, HoodieRec
     }
 
     public HoodieSinkDataConverter(@NonNull final Configuration conf, final String schema,
-                                   @NonNull final ErrorExtractor errorExtractor, HoodieConfiguration hoodieConfiguration) {
+                                   @NonNull final ErrorExtractor errorExtractor,
+                                   HoodieConfiguration hoodieConfiguration) {
         super(conf, errorExtractor);
         this.schema = schema;
         this.errorExtractor = errorExtractor;

--- a/marmaray/src/main/java/com/uber/marmaray/common/converters/data/HoodieSinkDataConverter.java
+++ b/marmaray/src/main/java/com/uber/marmaray/common/converters/data/HoodieSinkDataConverter.java
@@ -22,7 +22,9 @@ import com.uber.hoodie.common.model.HoodieRecord;
 import com.uber.hoodie.common.model.HoodieRecordPayload;
 import com.uber.marmaray.common.AvroPayload;
 import com.uber.marmaray.common.configuration.Configuration;
+import com.uber.marmaray.common.configuration.HoodieConfiguration;
 import com.uber.marmaray.common.converters.converterresult.ConverterResult;
+import com.uber.marmaray.common.exceptions.InvalidDataException;
 import com.uber.marmaray.common.metrics.DataFeedMetrics;
 import com.uber.marmaray.common.metrics.JobMetrics;
 import com.uber.marmaray.common.sinks.hoodie.HoodieSink;
@@ -35,27 +37,33 @@ import org.apache.avro.generic.GenericRecord;
 import java.util.Collections;
 import java.util.List;
 
+import com.google.common.base.Optional;
+
 /**
  * {@link HoodieSinkDataConverter} extends {@link SinkDataConverter}
  * This class is used by {@link HoodieSink} to generate {@link com.uber.hoodie.common.model.HoodieRecord} from
  * {@link com.uber.marmaray.common.AvroPayload}.
  */
-public abstract class HoodieSinkDataConverter extends SinkDataConverter<Schema, HoodieRecord<HoodieRecordPayload>> {
+public class HoodieSinkDataConverter extends SinkDataConverter<Schema, HoodieRecord<HoodieRecordPayload>> {
 
     // store the schema as a string since Schema doesn't serialize. Used in extended classes.
     protected String schema;
     private final ErrorExtractor errorExtractor;
+    private final HoodieConfiguration hoodieConfiguration;
 
-    public HoodieSinkDataConverter(@NonNull final Configuration conf, @NonNull final ErrorExtractor errorExtractor) {
+    public HoodieSinkDataConverter(@NonNull final Configuration conf, @NonNull final ErrorExtractor errorExtractor,
+                                   @NonNull final HoodieConfiguration hoodieConfiguration) {
         super(conf, errorExtractor);
         this.errorExtractor = errorExtractor;
+        this.hoodieConfiguration = hoodieConfiguration;
     }
 
     public HoodieSinkDataConverter(@NonNull final Configuration conf, final String schema,
-                                   @NonNull final ErrorExtractor errorExtractor) {
+                                   @NonNull final ErrorExtractor errorExtractor, HoodieConfiguration hoodieConfiguration) {
         super(conf, errorExtractor);
         this.schema = schema;
         this.errorExtractor = errorExtractor;
+        this.hoodieConfiguration = hoodieConfiguration;
     }
 
     @Override
@@ -82,7 +90,17 @@ public abstract class HoodieSinkDataConverter extends SinkDataConverter<Schema, 
      *
      * @param payload {@link AvroPayload}.
      */
-    protected abstract String getRecordKey(@NonNull final AvroPayload payload) throws Exception;
+    protected String getRecordKey(@NonNull final AvroPayload payload) throws Exception {
+        Optional<String> hoodieRecordKey = hoodieConfiguration.getHoodieRecordKey();
+        if (hoodieRecordKey.isPresent()) {
+            final Object recordKeyFieldVal = payload.getData().get(hoodieRecordKey.get());
+            if (recordKeyFieldVal == null) {
+                throw new InvalidDataException("required field is missing:" + hoodieRecordKey.get());
+            }
+            return recordKeyFieldVal.toString();
+        }
+        throw new Exception("Hoodie Record Key missing");
+    }
 
     /**
      * The implementation of it should use fields from {@link AvroPayload} to generate partition path which is needed
@@ -90,7 +108,17 @@ public abstract class HoodieSinkDataConverter extends SinkDataConverter<Schema, 
      *
      * @param payload {@link AvroPayload}.
      */
-    protected abstract String getPartitionPath(@NonNull final AvroPayload payload) throws Exception;
+    protected String getPartitionPath(@NonNull final AvroPayload payload) throws Exception {
+        Optional<String> hoodiePartitionPath = hoodieConfiguration.getHoodiePartitionPath();
+        if (hoodiePartitionPath.isPresent()) {
+            final Object partitionFieldVal = payload.getData().get(hoodiePartitionPath.get());
+            if (partitionFieldVal == null) {
+                throw new InvalidDataException("required field is missing:" + hoodiePartitionPath.get());
+            }
+            return partitionFieldVal.toString();
+        }
+        throw new Exception("Hoodie Partition Path missing");
+    }
 
     protected HoodieRecordPayload getPayload(@NonNull final AvroPayload payload) {
         return new HoodieAvroPayload(java.util.Optional.of(payload.getData()));

--- a/marmaray/src/main/java/com/uber/marmaray/common/schema/kafka/AbstractKafkaSchemaServiceReader.java
+++ b/marmaray/src/main/java/com/uber/marmaray/common/schema/kafka/AbstractKafkaSchemaServiceReader.java
@@ -1,0 +1,28 @@
+package com.uber.marmaray.common.schema.kafka;
+
+
+import com.uber.marmaray.common.schema.ISchemaService;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.Schema;
+import org.hibernate.validator.constraints.NotEmpty;
+
+import java.io.Serializable;
+
+@Slf4j
+public abstract class AbstractKafkaSchemaServiceReader implements ISchemaService.ISchemaServiceReader, Serializable {
+    private final String schemaString;
+    private transient Schema schema;
+
+    AbstractKafkaSchemaServiceReader(@NotEmpty final Schema schema) {
+        this.schemaString = schema.toString();
+        this.schema = schema;
+        log.info("Kafka Schema service reader initialised with schema {}", schemaString);
+    }
+
+    Schema getSchema() {
+        if (this.schema == null) {
+            this.schema = new Schema.Parser().parse(this.schemaString);
+        }
+        return this.schema;
+    }
+}

--- a/marmaray/src/main/java/com/uber/marmaray/common/schema/kafka/KafkaSchemaAvroServiceReader.java
+++ b/marmaray/src/main/java/com/uber/marmaray/common/schema/kafka/KafkaSchemaAvroServiceReader.java
@@ -1,0 +1,28 @@
+package com.uber.marmaray.common.schema.kafka;
+
+import com.uber.marmaray.common.exceptions.InvalidDataException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DecoderFactory;
+
+import java.io.IOException;
+
+public class KafkaSchemaAvroServiceReader extends AbstractKafkaSchemaServiceReader {
+    public KafkaSchemaAvroServiceReader(Schema schema) {
+        super(schema);
+    }
+
+    @Override
+    public GenericRecord read(byte[] buffer) throws InvalidDataException {
+        final DatumReader<GenericRecord> datumReader = new GenericDatumReader<>(getSchema());
+        BinaryDecoder decoder = DecoderFactory.get().binaryDecoder(buffer, null);
+        try {
+            return datumReader.read(null, decoder);
+        } catch (IOException e) {
+            throw new InvalidDataException("Error decoding data", e);
+        }
+    }
+}

--- a/marmaray/src/main/java/com/uber/marmaray/common/schema/kafka/KafkaSchemaJSONServiceReader.java
+++ b/marmaray/src/main/java/com/uber/marmaray/common/schema/kafka/KafkaSchemaJSONServiceReader.java
@@ -1,0 +1,28 @@
+package com.uber.marmaray.common.schema.kafka;
+
+import com.uber.marmaray.common.exceptions.InvalidDataException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.JsonDecoder;
+
+import java.io.IOException;
+
+public class KafkaSchemaJSONServiceReader extends AbstractKafkaSchemaServiceReader {
+    public KafkaSchemaJSONServiceReader(Schema schema) {
+        super(schema);
+    }
+
+    @Override
+    public GenericRecord read(byte[] buffer) throws InvalidDataException {
+        final DatumReader<GenericRecord> datumReader = new GenericDatumReader<>(getSchema());
+        try {
+            JsonDecoder decoder = DecoderFactory.get().jsonDecoder(getSchema(), new String(buffer));
+            return datumReader.read(null, decoder);
+        } catch (IOException e) {
+            throw new InvalidDataException("Error decoding data", e);
+        }
+    }
+}

--- a/marmaray/src/main/java/com/uber/marmaray/common/sinks/hoodie/HoodieErrorSink.java
+++ b/marmaray/src/main/java/com/uber/marmaray/common/sinks/hoodie/HoodieErrorSink.java
@@ -44,10 +44,9 @@ public class HoodieErrorSink extends HoodieSink {
     public HoodieErrorSink(@NonNull final HoodieConfiguration hoodieConf,
                            @NonNull final HoodieSinkDataConverter hoodieSinkDataConverter,
                            @NonNull final JavaSparkContext jsc,
-                           @NonNull final HoodieSinkOp op,
                            @NonNull final IMetadataManager metadataMgr,
                            final boolean shouldSaveChangesInFuture) {
-        super(hoodieConf, hoodieSinkDataConverter, jsc, op, metadataMgr, shouldSaveChangesInFuture, Optional.absent());
+        super(hoodieConf, hoodieSinkDataConverter, jsc, metadataMgr, shouldSaveChangesInFuture, Optional.absent());
     }
 
     public void writeRecordsAndErrors(@NonNull final HoodieWriteResult result) {

--- a/marmaray/src/main/java/com/uber/marmaray/common/sinks/hoodie/HoodieSink.java
+++ b/marmaray/src/main/java/com/uber/marmaray/common/sinks/hoodie/HoodieSink.java
@@ -175,7 +175,7 @@ public class HoodieSink implements ISink, scala.Serializable {
         final HoodieWriteConfig hoodieWriteConfig = this.hoodieConf.getHoodieWriteConfig();
         try (final HoodieWriteClientWrapper hoodieWriteClient = getHoodieWriteClient(hoodieWriteConfig)) {
             final String commitTime =
-                this.commitTime.isPresent() ? this.commitTime.get() : hoodieWriteClient.startCommit();
+                    this.commitTime.isPresent() ? this.commitTime.get() : hoodieWriteClient.startCommit();
 
             // Handle writes to hoodie. It can be an insert or upsert.
             final HoodieWriteResult result = handleWrite(hoodieWriteClient, hoodieRecords.getData(), commitTime, op);
@@ -191,7 +191,7 @@ public class HoodieSink implements ISink, scala.Serializable {
     protected void initDataset() {
         try {
             HoodieUtil.initHoodieDataset(FSUtils.getFs(this.hoodieConf.getConf(),
-                Optional.of(this.hoodieConf.getBasePath())), this.hoodieConf);
+                    Optional.of(this.hoodieConf.getBasePath())), this.hoodieConf);
         } catch (IOException e) {
             log.error("Error initializing hoodie dataset.", e);
             throw new JobRuntimeException("Could not initialize hoodie dataset", e);
@@ -202,6 +202,7 @@ public class HoodieSink implements ISink, scala.Serializable {
      * If {@link HoodieConfiguration#HOODIE_AUTO_TUNE_PARALLELISM} is enabled then it will use
      * {@link HoodieConfiguration#HOODIE_TARGET_FILE_SIZE} and {@link SinkStatManager#getAvgRecordSize()} to figure
      * out what should be the optimal insert parallelism.
+     *
      * @param numRecords
      */
     public boolean updateInsertParallelism(final long numRecords) {
@@ -209,7 +210,7 @@ public class HoodieSink implements ISink, scala.Serializable {
             final int newParallelism = calculateNewBulkInsertParallelism(numRecords);
             if (0 < newParallelism) {
                 this.hoodieConf.setTableProperty(HoodieConfiguration.HOODIE_INSERT_PARALLELISM,
-                    Integer.toString(newParallelism));
+                        Integer.toString(newParallelism));
                 log.info("new hoodie insert parallelism is set to :{}", newParallelism);
                 return true;
             }
@@ -221,6 +222,7 @@ public class HoodieSink implements ISink, scala.Serializable {
      * If {@link HoodieConfiguration#HOODIE_AUTO_TUNE_PARALLELISM} is enabled then it will use
      * {@link HoodieConfiguration#HOODIE_TARGET_FILE_SIZE} and {@link SinkStatManager#getAvgRecordSize()} to figure
      * out what should be the optimal bulk insert parallelism.
+     *
      * @param numRecords
      */
     public boolean updateBulkInsertParallelism(final long numRecords) {
@@ -228,7 +230,7 @@ public class HoodieSink implements ISink, scala.Serializable {
             final int newParallelism = calculateNewBulkInsertParallelism(numRecords);
             if (0 < newParallelism) {
                 this.hoodieConf.setTableProperty(HoodieConfiguration.HOODIE_BULKINSERT_PARALLELISM,
-                    Integer.toString(newParallelism));
+                        Integer.toString(newParallelism));
                 log.info("new hoodie bulk insert parallelism is set to :{}", newParallelism);
                 return true;
             }
@@ -244,7 +246,7 @@ public class HoodieSink implements ISink, scala.Serializable {
         final int currentParallelism = this.hoodieConf.getBulkInsertParallelism();
         log.info(
                 "StatsManager:targetFileSize:{}:avgRecordSize:{}:numRecords:{}:"
-                + "newBulkInsertParallelism:{}:currentBulkInsertParallelism:{}",
+                        + "newBulkInsertParallelism:{}:currentBulkInsertParallelism:{}",
                 targetFileSize, avgRecordSize, numRecords, newParallelism, currentParallelism);
         return newParallelism;
     }
@@ -252,8 +254,8 @@ public class HoodieSink implements ISink, scala.Serializable {
     @VisibleForTesting
     protected HoodieWriteClientWrapper getHoodieWriteClient(@NonNull final HoodieWriteConfig hoodieWriteConfig) {
         final HoodieWriteClient<HoodieRecordPayload> hoodieWriteClient =
-            new HoodieWriteClient<HoodieRecordPayload>(this.jsc, hoodieWriteConfig,
-                this.hoodieConf.shouldRollbackInFlight());
+                new HoodieWriteClient<HoodieRecordPayload>(this.jsc, hoodieWriteConfig,
+                        this.hoodieConf.shouldRollbackInFlight());
         return new HoodieWriteClientWrapper(hoodieWriteClient, this.bulkInsertPartitioner);
     }
 
@@ -262,15 +264,15 @@ public class HoodieSink implements ISink, scala.Serializable {
      * {@link HoodieBasedMetadataManager#shouldSaveChanges()} flag.
      */
     public void commit(@NonNull final HoodieWriteClientWrapper hoodieWriteClient,
-                          @NotEmpty final String commitTime,
-                          @NonNull final Optional<JavaRDD<WriteStatus>> writesStatuses) {
+                       @NotEmpty final String commitTime,
+                       @NonNull final Optional<JavaRDD<WriteStatus>> writesStatuses) {
         this.commit(hoodieWriteClient, commitTime, writesStatuses, this.shouldSaveChangesInFuture);
     }
 
     public void commit(@NonNull final HoodieWriteClientWrapper hoodieWriteClient,
-                          @NotEmpty final String commitTime,
-                          @NonNull final Optional<JavaRDD<WriteStatus>> writesStatuses,
-                          final boolean shouldSaveChangesInFuture) {
+                       @NotEmpty final String commitTime,
+                       @NonNull final Optional<JavaRDD<WriteStatus>> writesStatuses,
+                       final boolean shouldSaveChangesInFuture) {
         updateSinkStat(writesStatuses);
         logWriteMetrics(writesStatuses);
 
@@ -328,9 +330,9 @@ public class HoodieSink implements ISink, scala.Serializable {
             final LongAccumulator totalCount = writesStatuses.get().rdd().sparkContext().longAccumulator();
             final LongAccumulator errorCount = writesStatuses.get().rdd().sparkContext().longAccumulator();
             writesStatuses.get().foreach(writeStatus -> {
-                    errorCount.add(writeStatus.getFailedRecords().size());
-                    totalCount.add(writeStatus.getTotalRecords());
-                });
+                errorCount.add(writeStatus.getFailedRecords().size());
+                totalCount.add(writeStatus.getTotalRecords());
+            });
             this.dataFeedMetrics.get().createLongMetric(DataFeedMetricNames.ERROR_ROWCOUNT, errorCount.value(),
                     this.dataFeedMetricsTags);
             this.dataFeedMetrics.get().createLongMetric(DataFeedMetricNames.OUTPUT_ROWCOUNT,
@@ -341,6 +343,7 @@ public class HoodieSink implements ISink, scala.Serializable {
     /**
      * {@link #updateSinkStat(Optional)} will compute {@link SinkStat} and persist changes into {@link IMetadataManager}.
      * As a part of {@link SinkStat} computation; it will compute avg record size for current run.
+     *
      * @param writesStatuses
      */
     private void updateSinkStat(final Optional<JavaRDD<WriteStatus>> writesStatuses) {
@@ -349,16 +352,16 @@ public class HoodieSink implements ISink, scala.Serializable {
             final LongAccumulator fileCount = writesStatuses.get().rdd().sparkContext().longAccumulator();
             final LongAccumulator totalSize = writesStatuses.get().rdd().sparkContext().longAccumulator();
             writesStatuses.get().foreach(
-                writeStatus -> {
-                    final long writeBytes = writeStatus.getStat().getTotalWriteBytes();
-                    final long numInserts = writeStatus.getStat().getNumWrites()
-                            - writeStatus.getStat().getNumUpdateWrites();
-                    if (writeBytes > 0 && numInserts > 0) {
-                        avgRecordSizeCounter.add(writeBytes / numInserts);
+                    writeStatus -> {
+                        final long writeBytes = writeStatus.getStat().getTotalWriteBytes();
+                        final long numInserts = writeStatus.getStat().getNumWrites()
+                                - writeStatus.getStat().getNumUpdateWrites();
+                        if (writeBytes > 0 && numInserts > 0) {
+                            avgRecordSizeCounter.add(writeBytes / numInserts);
+                        }
+                        fileCount.add(1);
+                        totalSize.add(writeBytes);
                     }
-                    fileCount.add(1);
-                    totalSize.add(writeBytes);
-                }
             );
             final long avgRecordSize = (int) avgRecordSizeCounter.avg();
             if (avgRecordSize > 0) {
@@ -367,9 +370,9 @@ public class HoodieSink implements ISink, scala.Serializable {
             }
             if (this.dataFeedMetrics.isPresent()) {
                 this.dataFeedMetrics.get().createLongMetric(DataFeedMetricNames.TOTAL_FILE_COUNT, fileCount.value(),
-                    this.dataFeedMetricsTags);
+                        this.dataFeedMetricsTags);
                 this.dataFeedMetrics.get().createLongMetric(DataFeedMetricNames.TOTAL_WRITE_SIZE, totalSize.value(),
-                    this.dataFeedMetricsTags);
+                        this.dataFeedMetricsTags);
             }
         }
         this.sinkStatMgr.persist();
@@ -444,7 +447,7 @@ public class HoodieSink implements ISink, scala.Serializable {
     }
 
     private JavaRDD<HoodieRecord<HoodieRecordPayload>> dedupRecords(@NonNull final HoodieWriteClientWrapper writeClient,
-        @NonNull final JavaRDD<HoodieRecord<HoodieRecordPayload>> hoodieRecords) {
+                                                                    @NonNull final JavaRDD<HoodieRecord<HoodieRecordPayload>> hoodieRecords) {
         return writeClient.filterExists(hoodieRecords).persist(StorageLevel.DISK_ONLY());
     }
 
@@ -454,11 +457,11 @@ public class HoodieSink implements ISink, scala.Serializable {
      * see {@link UserDefinedBulkInsertPartitioner}.
      */
     public static UserDefinedBulkInsertPartitioner getDataPartitioner(@NonNull final HoodieConfiguration hoodieConf,
-        @NonNull final Optional<String> defaultDataPartitioner) {
+                                                                      @NonNull final Optional<String> defaultDataPartitioner) {
         try {
             return (UserDefinedBulkInsertPartitioner) Class.forName(hoodieConf.getHoodieDataPartitioner(
-                defaultDataPartitioner.isPresent() ? defaultDataPartitioner.get()
-                    : DefaultHoodieDataPartitioner.class.getName())).newInstance();
+                    defaultDataPartitioner.isPresent() ? defaultDataPartitioner.get()
+                            : DefaultHoodieDataPartitioner.class.getName())).newInstance();
         } catch (InstantiationException | IllegalAccessException | ClassNotFoundException | ClassCastException e) {
             throw new JobRuntimeException("exception in initializing data partitioner", e);
         }
@@ -485,22 +488,22 @@ public class HoodieSink implements ISink, scala.Serializable {
         }
 
         public boolean commit(@NotEmpty final String commitTime, @NonNull final JavaRDD<WriteStatus> writeStatuses,
-            final java.util.Optional<HashMap<String, String>> extraMetadata) {
+                              final java.util.Optional<HashMap<String, String>> extraMetadata) {
             return this.hoodieWriteClient.commit(commitTime, writeStatuses, extraMetadata);
         }
 
         public JavaRDD<WriteStatus> insert(@NonNull final JavaRDD<HoodieRecord<HoodieRecordPayload>> records,
-            @NotEmpty final String commitTime) {
+                                           @NotEmpty final String commitTime) {
             return this.hoodieWriteClient.insert(records, commitTime);
         }
 
         public JavaRDD<WriteStatus> bulkInsert(@NonNull final JavaRDD<HoodieRecord<HoodieRecordPayload>> records,
-            @NotEmpty final String commitTime) {
+                                               @NotEmpty final String commitTime) {
             return this.hoodieWriteClient.bulkInsert(records, commitTime, Option.apply(this.bulkInsertPartitioner));
         }
 
         public JavaRDD<WriteStatus> upsert(@NonNull final JavaRDD<HoodieRecord<HoodieRecordPayload>> records,
-            @NotEmpty final String commitTime) {
+                                           @NotEmpty final String commitTime) {
             return this.hoodieWriteClient.upsert(records, commitTime);
         }
 
@@ -522,7 +525,7 @@ public class HoodieSink implements ISink, scala.Serializable {
         }
 
         public JavaRDD<HoodieRecord<HoodieRecordPayload>> filterExists(
-            final JavaRDD<HoodieRecord<HoodieRecordPayload>> hoodieRecords) {
+                final JavaRDD<HoodieRecord<HoodieRecordPayload>> hoodieRecords) {
             return this.hoodieWriteClient.filterExists(hoodieRecords);
         }
     }
@@ -531,17 +534,29 @@ public class HoodieSink implements ISink, scala.Serializable {
      * Supported hoodie write operations.
      */
     public enum HoodieSinkOp {
-        /** {@link HoodieWriteClient#insert(JavaRDD, String)}*/
+        /**
+         * {@link HoodieWriteClient#insert(JavaRDD, String)}
+         */
         INSERT,
-        /** {@link HoodieWriteClient#bulkInsert(JavaRDD, String)}*/
+        /**
+         * {@link HoodieWriteClient#bulkInsert(JavaRDD, String)}
+         */
         BULK_INSERT,
-        /** {@link HoodieWriteClient#insert(JavaRDD, String)} {@link HoodieWriteClient#filterExists(JavaRDD)}*/
+        /**
+         * {@link HoodieWriteClient#insert(JavaRDD, String)} {@link HoodieWriteClient#filterExists(JavaRDD)}
+         */
         DEDUP_INSERT,
-        /** {@link HoodieWriteClient#bulkInsert(JavaRDD, String)} {@link HoodieWriteClient#filterExists(JavaRDD)}*/
+        /**
+         * {@link HoodieWriteClient#bulkInsert(JavaRDD, String)} {@link HoodieWriteClient#filterExists(JavaRDD)}
+         */
         DEDUP_BULK_INSERT,
-        /** {@link com.uber.hoodie.HoodieWriteClient#upsert(org.apache.spark.api.java.JavaRDD, java.lang.String)}*/
+        /**
+         * {@link com.uber.hoodie.HoodieWriteClient#upsert(org.apache.spark.api.java.JavaRDD, java.lang.String)}
+         */
         UPSERT,
-        /** No operation */
+        /**
+         * No operation
+         */
         NO_OP
     }
 

--- a/marmaray/src/main/java/com/uber/marmaray/common/sinks/hoodie/HoodieSink.java
+++ b/marmaray/src/main/java/com/uber/marmaray/common/sinks/hoodie/HoodieSink.java
@@ -116,23 +116,21 @@ public class HoodieSink implements ISink, scala.Serializable {
     public HoodieSink(@NonNull final HoodieConfiguration hoodieConf,
                       @NonNull final HoodieSinkDataConverter hoodieSinkDataConverter,
                       @NonNull final JavaSparkContext jsc,
-                      @NonNull final HoodieSinkOp op,
                       @NonNull final IMetadataManager metadataMgr,
                       @NonNull final Optional<String> defaultDataPartitioner) {
-      this(hoodieConf, hoodieSinkDataConverter, jsc, op, metadataMgr, false, defaultDataPartitioner);
+      this(hoodieConf, hoodieSinkDataConverter, jsc, metadataMgr, false, defaultDataPartitioner);
     }
 
     public HoodieSink(@NonNull final HoodieConfiguration hoodieConf,
                       @NonNull final HoodieSinkDataConverter hoodieSinkDataConverter,
                       @NonNull final JavaSparkContext jsc,
-                      @NonNull final HoodieSinkOp op,
                       @NonNull final IMetadataManager metadataMgr,
                       final boolean shouldSaveChangesInFuture,
                       @NonNull final Optional<String> defaultDataPartitioner) {
         this.hoodieConf = hoodieConf;
         this.hoodieSinkDataConverter = hoodieSinkDataConverter;
         this.jsc = jsc;
-        this.op = op;
+        this.op = hoodieConf.getHoodieSinkOp();
         this.metadataMgr = metadataMgr;
         this.sinkStatMgr = new SinkStatManager(this.hoodieConf.getTableName(), this.metadataMgr);
         this.sinkStatMgr.init();

--- a/marmaray/src/main/java/com/uber/marmaray/examples/job/KafkaToHoodieJob.java
+++ b/marmaray/src/main/java/com/uber/marmaray/examples/job/KafkaToHoodieJob.java
@@ -165,8 +165,8 @@ public class KafkaToHoodieJob {
             // Sink
             HoodieSinkDataConverter hoodieSinkDataConverter = new HoodieSinkDataConverter(conf, new ErrorExtractor(),
                     hoodieConf);
-            HoodieSink hoodieSink = new HoodieSink(hoodieConf, hoodieSinkDataConverter, jsc,
-                    HoodieSink.HoodieSinkOp.INSERT, metadataManager, Optional.absent());
+            HoodieSink hoodieSink = new HoodieSink(hoodieConf, hoodieSinkDataConverter, jsc, metadataManager,
+                    Optional.absent());
 
             log.info("Initializing work unit calculator for job");
             final IWorkUnitCalculator workUnitCalculator = new KafkaWorkUnitCalculator(kafkaSourceConf);

--- a/marmaray/src/main/java/com/uber/marmaray/examples/job/KafkaToHoodieJob.java
+++ b/marmaray/src/main/java/com/uber/marmaray/examples/job/KafkaToHoodieJob.java
@@ -20,7 +20,6 @@ import com.uber.marmaray.common.metrics.ModuleTagNames;
 import com.uber.marmaray.common.metrics.TimerMetric;
 import com.uber.marmaray.common.reporters.ConsoleReporter;
 import com.uber.marmaray.common.reporters.Reporters;
-import com.uber.marmaray.common.schema.kafka.KafkaSchemaAvroServiceReader;
 import com.uber.marmaray.common.schema.kafka.KafkaSchemaJSONServiceReader;
 import com.uber.marmaray.common.sinks.hoodie.HoodieSink;
 import com.uber.marmaray.common.sources.ISource;
@@ -75,7 +74,6 @@ class CustomHoodieSinkDataConverter extends HoodieSinkDataConverter {
 }
 
 
-
 /**
  * Job to load data from kafka to hoodie
  */
@@ -99,20 +97,6 @@ public class KafkaToHoodieJob {
      * @throws IOException
      */
     private void run(final String[] args) throws IOException {
-//        final String schema = "{\"namespace\": \"example.avro\", \"type\": \"record\", \"name\": \"Record\", \"fields\": [{\"name\": \"Region\", \"type\": \"string\"}, {\"name\": \"Country\", \"type\": \"string\"}] }";
-//        final Schema schemaObj = new org.apache.avro.Schema.Parser().parse(schema);
-//        final GenericData.Record record = new GenericData.Record(schemaObj);
-//        record.put("Region", "Sub-Saharan Africa");
-//        record.put("Country", "Chad");
-//
-//        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-//        final GenericDatumWriter datumWriter = new GenericDatumWriter<GenericRecord>(schemaObj);
-//        final BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(outputStream, null);
-//
-//        datumWriter.write(record, encoder);
-//        encoder.flush();
-//
-//        final String recordString = new String(outputStream.toByteArray());
 
         final Instant jobStartTime = Instant.now();
 
@@ -122,7 +106,7 @@ public class KafkaToHoodieJob {
         reporters.addReporter(new ConsoleReporter());
 
         final Map<String, String> metricTags = Collections.emptyMap();
-        final DataFeedMetrics dataFeedMetrics = new DataFeedMetrics("kafka to hoodie ingestion", metricTags);
+        final DataFeedMetrics dataFeedMetrics = new DataFeedMetrics("KafkaToHoodieJob", metricTags);
 
         log.info("Initializing configurations for job");
         final TimerMetric confInitMetric = new TimerMetric(DataFeedMetricNames.INIT_CONFIG_LATENCY_MS,
@@ -149,16 +133,7 @@ public class KafkaToHoodieJob {
         final TimerMetric convertSchemaLatencyMs =
                 new TimerMetric(DataFeedMetricNames.CONVERT_SCHEMA_LATENCY_MS, metricTags);
 
-//        final StructType inputSchema = DataTypes.createStructType(new StructField[]{
-//                DataTypes.createStructField("Region", DataTypes.StringType, true),
-//                DataTypes.createStructField("Country", DataTypes.StringType, true)
-//        });
-//
-//        final DataFrameSchemaConverter schemaConverter = new DataFrameSchemaConverter();
-//        final Schema outputSchema = schemaConverter.convertToCommonSchema(inputSchema);
-
-        final String schema = "{\"namespace\": \"example.avro\", \"type\": \"record\", \"name\": \"Record\", \"fields\": [{\"name\": \"Region\", \"type\": \"string\"}, {\"name\": \"Country\", \"type\": \"string\"}] }";
-        final Schema outputSchema = new org.apache.avro.Schema.Parser().parse(schema);
+        final Schema outputSchema = new Schema.Parser().parse(hoodieConf.getHoodieWriteConfig().getSchema());
         convertSchemaLatencyMs.stop();
         reporters.report(convertSchemaLatencyMs);
 

--- a/marmaray/src/main/java/com/uber/marmaray/examples/job/KafkaToHoodieJob.java
+++ b/marmaray/src/main/java/com/uber/marmaray/examples/job/KafkaToHoodieJob.java
@@ -21,6 +21,7 @@ import com.uber.marmaray.common.metrics.TimerMetric;
 import com.uber.marmaray.common.reporters.ConsoleReporter;
 import com.uber.marmaray.common.reporters.Reporters;
 import com.uber.marmaray.common.schema.kafka.KafkaSchemaAvroServiceReader;
+import com.uber.marmaray.common.schema.kafka.KafkaSchemaJSONServiceReader;
 import com.uber.marmaray.common.sinks.hoodie.HoodieSink;
 import com.uber.marmaray.common.sources.ISource;
 import com.uber.marmaray.common.sources.IWorkUnitCalculator;
@@ -197,7 +198,7 @@ public class KafkaToHoodieJob {
 
             // Schema
             log.info("Initializing source data converter");
-            KafkaSchemaAvroServiceReader serviceReader = new KafkaSchemaAvroServiceReader(outputSchema);
+            KafkaSchemaJSONServiceReader serviceReader = new KafkaSchemaJSONServiceReader(outputSchema);
             final KafkaSourceDataConverter dataConverter = new KafkaSourceDataConverter(serviceReader, conf, new ErrorExtractor());
 
             log.info("Initializing source & sink for job");

--- a/marmaray/src/main/java/com/uber/marmaray/examples/job/KafkaToHoodieJob.java
+++ b/marmaray/src/main/java/com/uber/marmaray/examples/job/KafkaToHoodieJob.java
@@ -178,7 +178,7 @@ public class KafkaToHoodieJob {
 
             jobManager.addJobDag(jobDag);
 
-            log.info("Running dispersal job");
+            log.info("Running ingestion job");
             try {
                 jobManager.run();
                 JobUtil.raiseExceptionIfStatusFailed(jobManager.getJobManagerStatus());
@@ -195,7 +195,7 @@ public class KafkaToHoodieJob {
                 reporters.report(configError);
                 throw t;
             }
-            log.info("Dispersal job has been completed");
+            log.info("Ingestion job has been completed");
 
             final TimerMetric jobLatencyMetric =
                     new TimerMetric(JobMetricNames.RUN_JOB_DAG_LATENCY_MS, metricTags, jobStartTime);

--- a/marmaray/src/main/java/com/uber/marmaray/examples/job/KafkaToHoodieJob.java
+++ b/marmaray/src/main/java/com/uber/marmaray/examples/job/KafkaToHoodieJob.java
@@ -80,7 +80,6 @@ class CustomHoodieSinkDataConverter extends HoodieSinkDataConverter {
  */
 @Slf4j
 public class KafkaToHoodieJob {
-
     /**
      * Generic entry point
      *

--- a/marmaray/src/main/java/com/uber/marmaray/examples/job/KafkaToHoodieJob.java
+++ b/marmaray/src/main/java/com/uber/marmaray/examples/job/KafkaToHoodieJob.java
@@ -47,31 +47,12 @@ import parquet.Preconditions;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import com.uber.marmaray.common.AvroPayload;
 import com.uber.marmaray.common.configuration.Configuration;
 import com.uber.marmaray.common.converters.data.HoodieSinkDataConverter;
-
-
-class CustomHoodieSinkDataConverter extends HoodieSinkDataConverter {
-    CustomHoodieSinkDataConverter(Configuration conf, ErrorExtractor errorExtractor) {
-        super(conf, errorExtractor);
-    }
-
-    @Override
-    protected String getRecordKey(AvroPayload avroPayload) {
-        return "Region";
-    }
-
-    @Override
-    protected String getPartitionPath(AvroPayload avroPayload) {
-        return "test";
-    }
-}
 
 
 /**
@@ -182,8 +163,8 @@ public class KafkaToHoodieJob {
                     Optional.absent(), Optional.absent());
 
             // Sink
-            HoodieSinkDataConverter hoodieSinkDataConverter = new CustomHoodieSinkDataConverter(conf,
-                    new ErrorExtractor());
+            HoodieSinkDataConverter hoodieSinkDataConverter = new HoodieSinkDataConverter(conf, new ErrorExtractor(),
+                    hoodieConf);
             HoodieSink hoodieSink = new HoodieSink(hoodieConf, hoodieSinkDataConverter, jsc,
                     HoodieSink.HoodieSinkOp.INSERT, metadataManager, Optional.absent());
 

--- a/marmaray/src/main/java/com/uber/marmaray/examples/job/KafkaToHoodieJob.java
+++ b/marmaray/src/main/java/com/uber/marmaray/examples/job/KafkaToHoodieJob.java
@@ -84,7 +84,7 @@ public class KafkaToHoodieJob {
      * Generic entry point
      *
      * @param args arguments for the job, from the command line
-     * @throws IOException
+     * @throws IOException Exception
      */
     public static void main(final String[] args) throws IOException {
         new KafkaToHoodieJob().run(args);
@@ -94,7 +94,7 @@ public class KafkaToHoodieJob {
      * Main execution method for the job.
      *
      * @param args command line arguments
-     * @throws IOException
+     * @throws IOException Exception
      */
     private void run(final String[] args) throws IOException {
 
@@ -138,7 +138,7 @@ public class KafkaToHoodieJob {
         reporters.report(convertSchemaLatencyMs);
 
         final SparkArgs sparkArgs = new SparkArgs(
-                Arrays.asList(outputSchema),
+                Collections.singletonList(outputSchema),
                 SparkUtil.getSerializationClasses(),
                 conf);
         final SparkFactory sparkFactory = new SparkFactory(sparkArgs);
@@ -174,14 +174,18 @@ public class KafkaToHoodieJob {
             // Schema
             log.info("Initializing source data converter");
             KafkaSchemaJSONServiceReader serviceReader = new KafkaSchemaJSONServiceReader(outputSchema);
-            final KafkaSourceDataConverter dataConverter = new KafkaSourceDataConverter(serviceReader, conf, new ErrorExtractor());
+            final KafkaSourceDataConverter dataConverter = new KafkaSourceDataConverter(serviceReader, conf,
+                    new ErrorExtractor());
 
             log.info("Initializing source & sink for job");
-            final ISource kafkaSource = new KafkaSource(kafkaSourceConf, Optional.of(jsc), dataConverter, Optional.absent(), Optional.absent());
+            final ISource kafkaSource = new KafkaSource(kafkaSourceConf, Optional.of(jsc), dataConverter,
+                    Optional.absent(), Optional.absent());
 
             // Sink
-            HoodieSinkDataConverter hoodieSinkDataConverter = new CustomHoodieSinkDataConverter(conf, new ErrorExtractor());
-            HoodieSink hoodieSink = new HoodieSink(hoodieConf, hoodieSinkDataConverter, jsc, HoodieSink.HoodieSinkOp.INSERT, metadataManager, Optional.absent());
+            HoodieSinkDataConverter hoodieSinkDataConverter = new CustomHoodieSinkDataConverter(conf,
+                    new ErrorExtractor());
+            HoodieSink hoodieSink = new HoodieSink(hoodieConf, hoodieSinkDataConverter, jsc,
+                    HoodieSink.HoodieSinkOp.INSERT, metadataManager, Optional.absent());
 
             log.info("Initializing work unit calculator for job");
             final IWorkUnitCalculator workUnitCalculator = new KafkaWorkUnitCalculator(kafkaSourceConf);
@@ -280,7 +284,8 @@ public class KafkaToHoodieJob {
      * @param jsc  Java spark context
      * @return metadata manager
      */
-    private static IMetadataManager initMetadataManager(@NonNull final HoodieConfiguration conf, @NonNull final JavaSparkContext jsc) {
+    private static IMetadataManager initMetadataManager(@NonNull final HoodieConfiguration conf,
+                                                        @NonNull final JavaSparkContext jsc) {
         log.info("Create metadata manager");
         try {
             return new HoodieBasedMetadataManager(conf, new AtomicBoolean(true), jsc);

--- a/marmaray/src/main/java/com/uber/marmaray/examples/job/KafkaToHoodieJob.java
+++ b/marmaray/src/main/java/com/uber/marmaray/examples/job/KafkaToHoodieJob.java
@@ -1,0 +1,378 @@
+package com.uber.marmaray.examples.job;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.google.common.base.Optional;
+import com.uber.marmaray.common.configuration.*;
+import com.uber.marmaray.common.converters.data.*;
+import com.uber.marmaray.common.exceptions.JobRuntimeException;
+import com.uber.marmaray.common.job.JobDag;
+import com.uber.marmaray.common.job.JobManager;
+import com.uber.marmaray.common.metadata.HoodieBasedMetadataManager;
+import com.uber.marmaray.common.metadata.IMetadataManager;
+import com.uber.marmaray.common.metrics.DataFeedMetricNames;
+import com.uber.marmaray.common.metrics.DataFeedMetrics;
+import com.uber.marmaray.common.metrics.ErrorCauseTagNames;
+import com.uber.marmaray.common.metrics.JobMetricNames;
+import com.uber.marmaray.common.metrics.JobMetrics;
+import com.uber.marmaray.common.metrics.LongMetric;
+import com.uber.marmaray.common.metrics.ModuleTagNames;
+import com.uber.marmaray.common.metrics.TimerMetric;
+import com.uber.marmaray.common.reporters.ConsoleReporter;
+import com.uber.marmaray.common.reporters.Reporters;
+import com.uber.marmaray.common.sinks.hoodie.HoodieSink;
+import com.uber.marmaray.common.sources.ISource;
+import com.uber.marmaray.common.sources.IWorkUnitCalculator;
+import com.uber.marmaray.common.sources.kafka.KafkaSource;
+import com.uber.marmaray.common.sources.kafka.KafkaWorkUnitCalculator;
+import com.uber.marmaray.common.spark.SparkArgs;
+import com.uber.marmaray.common.spark.SparkFactory;
+import com.uber.marmaray.utilities.SparkUtil;
+import com.uber.marmaray.utilities.ErrorExtractor;
+import com.uber.marmaray.utilities.FSUtils;
+import com.uber.marmaray.utilities.JobUtil;
+import com.uber.marmaray.utilities.listener.TimeoutManager;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.SQLContext;
+import org.hibernate.validator.constraints.NotEmpty;
+import parquet.Preconditions;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.uber.marmaray.common.AvroPayload;
+import com.uber.marmaray.common.configuration.Configuration;
+import com.uber.marmaray.common.converters.data.HoodieSinkDataConverter;
+import com.uber.marmaray.common.exceptions.InvalidDataException;
+import com.uber.marmaray.common.schema.ISchemaService;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.*;
+import java.io.Serializable;
+
+
+class KafkaSchemaServiceReader implements ISchemaService.ISchemaServiceReader, Serializable {
+
+    private final String schemaString;
+    private transient Schema schema;
+
+    KafkaSchemaServiceReader(@NotEmpty final Schema schema) {
+        this.schemaString = schema.toString();
+        this.schema = schema;
+    }
+
+    private Schema getSchema() {
+        if (this.schema == null) {
+            this.schema = new Schema.Parser().parse(this.schemaString);
+        }
+        return this.schema;
+    }
+
+    @Override
+    public GenericRecord read(final byte[] buffer) throws InvalidDataException {
+        final DatumReader<GenericRecord> datumReader = new GenericDatumReader<>(getSchema());
+        BinaryDecoder decoder = DecoderFactory.get().binaryDecoder(buffer, null);
+        try {
+            return datumReader.read(null, decoder);
+        } catch (IOException e) {
+            throw new InvalidDataException("Error decoding data", e);
+        }
+
+
+        // JSON reader
+//        DatumReader<GenericRecord> reader = new GenericDatumReader<>(this.getSchema());
+//
+//        try {
+//            JsonDecoder jsonDecoder = DecoderFactory.get().jsonDecoder(this.getSchema(), new String(buffer));
+//            return reader.read(null, jsonDecoder);
+//        } catch (IOException e) {
+//            throw new InvalidDataException("Error decoding data", e);
+//        }
+    }
+}
+
+class CustomHoodieSinkDataConverter extends HoodieSinkDataConverter {
+    CustomHoodieSinkDataConverter(Configuration conf, ErrorExtractor errorExtractor) {
+        super(conf, errorExtractor);
+    }
+
+    @Override
+    protected String getRecordKey(AvroPayload avroPayload) {
+        return "Region";
+    }
+
+    @Override
+    protected String getPartitionPath(AvroPayload avroPayload) {
+        return "test";
+    }
+}
+
+
+
+/**
+ * Job to load data from kafka to hoodie
+ */
+@Slf4j
+public class KafkaToHoodieJob {
+
+    /**
+     * Generic entry point
+     *
+     * @param args arguments for the job, from the command line
+     * @throws IOException
+     */
+    public static void main(final String[] args) throws IOException {
+        new KafkaToHoodieJob().run(args);
+    }
+
+    /**
+     * Main execution method for the job.
+     *
+     * @param args command line arguments
+     * @throws IOException
+     */
+    private void run(final String[] args) throws IOException {
+//        final String schema = "{\"namespace\": \"example.avro\", \"type\": \"record\", \"name\": \"Record\", \"fields\": [{\"name\": \"Region\", \"type\": \"string\"}, {\"name\": \"Country\", \"type\": \"string\"}] }";
+//        final Schema schemaObj = new org.apache.avro.Schema.Parser().parse(schema);
+//        final GenericData.Record record = new GenericData.Record(schemaObj);
+//        record.put("Region", "Sub-Saharan Africa");
+//        record.put("Country", "Chad");
+//
+//        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+//        final GenericDatumWriter datumWriter = new GenericDatumWriter<GenericRecord>(schemaObj);
+//        final BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(outputStream, null);
+//
+//        datumWriter.write(record, encoder);
+//        encoder.flush();
+//
+//        final String recordString = new String(outputStream.toByteArray());
+
+        final Instant jobStartTime = Instant.now();
+
+        final Configuration conf = getConfiguration(args);
+
+        final Reporters reporters = new Reporters();
+        reporters.addReporter(new ConsoleReporter());
+
+        final Map<String, String> metricTags = Collections.emptyMap();
+        final DataFeedMetrics dataFeedMetrics = new DataFeedMetrics("kafka to hoodie ingestion", metricTags);
+
+        log.info("Initializing configurations for job");
+        final TimerMetric confInitMetric = new TimerMetric(DataFeedMetricNames.INIT_CONFIG_LATENCY_MS,
+                metricTags);
+
+        final KafkaSourceConfiguration kafkaSourceConf;
+        final HoodieConfiguration hoodieConf;
+        try {
+            kafkaSourceConf = new KafkaSourceConfiguration(conf);
+            hoodieConf = new HoodieConfiguration(conf, "test_hoodie");
+        } catch (final Exception e) {
+            final LongMetric configError = new LongMetric(DataFeedMetricNames.DISPERSAL_CONFIGURATION_INIT_ERRORS, 1);
+            configError.addTags(metricTags);
+            configError.addTags(DataFeedMetricNames
+                    .getErrorModuleCauseTags(ModuleTagNames.CONFIGURATION, ErrorCauseTagNames.CONFIG_ERROR));
+            reporters.report(configError);
+            reporters.getReporters().forEach(dataFeedMetrics::gauageFailureMetric);
+            throw e;
+        }
+        confInitMetric.stop();
+        reporters.report(confInitMetric);
+
+        log.info("Reading schema");
+        final TimerMetric convertSchemaLatencyMs =
+                new TimerMetric(DataFeedMetricNames.CONVERT_SCHEMA_LATENCY_MS, metricTags);
+
+//        final StructType inputSchema = DataTypes.createStructType(new StructField[]{
+//                DataTypes.createStructField("Region", DataTypes.StringType, true),
+//                DataTypes.createStructField("Country", DataTypes.StringType, true)
+//        });
+//
+//        final DataFrameSchemaConverter schemaConverter = new DataFrameSchemaConverter();
+//        final Schema outputSchema = schemaConverter.convertToCommonSchema(inputSchema);
+
+        final String schema = "{\"namespace\": \"example.avro\", \"type\": \"record\", \"name\": \"Record\", \"fields\": [{\"name\": \"Region\", \"type\": \"string\"}, {\"name\": \"Country\", \"type\": \"string\"}] }";
+        final Schema outputSchema = new org.apache.avro.Schema.Parser().parse(schema);
+        convertSchemaLatencyMs.stop();
+        reporters.report(convertSchemaLatencyMs);
+
+        final SparkArgs sparkArgs = new SparkArgs(
+                Arrays.asList(outputSchema),
+                SparkUtil.getSerializationClasses(),
+                conf);
+        final SparkFactory sparkFactory = new SparkFactory(sparkArgs);
+        final JobManager jobManager = JobManager.createJobManager(conf, "marmaray",
+                "frequency", sparkFactory, reporters);
+
+        final JavaSparkContext jsc = sparkFactory.getSparkContext();
+
+        log.info("Initializing metadata manager for job");
+        final TimerMetric metadataManagerInitMetric =
+                new TimerMetric(DataFeedMetricNames.INIT_METADATAMANAGER_LATENCY_MS, metricTags);
+        final IMetadataManager metadataManager;
+        try {
+            metadataManager = initMetadataManager(hoodieConf, jsc);
+        } catch (final JobRuntimeException e) {
+            final LongMetric configError = new LongMetric(DataFeedMetricNames.DISPERSAL_CONFIGURATION_INIT_ERRORS, 1);
+            configError.addTags(metricTags);
+            configError.addTags(DataFeedMetricNames
+                    .getErrorModuleCauseTags(ModuleTagNames.METADATA_MANAGER, ErrorCauseTagNames.CONFIG_ERROR));
+            reporters.report(configError);
+            reporters.getReporters().forEach(dataFeedMetrics::gauageFailureMetric);
+            throw e;
+        }
+        metadataManagerInitMetric.stop();
+        reporters.report(metadataManagerInitMetric);
+
+        try {
+            log.info("Initializing converters & schemas for job");
+            final SQLContext sqlContext = SQLContext.getOrCreate(jsc.sc());
+
+            log.info("Common schema is: {}", outputSchema.toString());
+
+            // Schema
+            log.info("Initializing source data converter");
+            KafkaSchemaServiceReader serviceReader = new KafkaSchemaServiceReader(outputSchema);
+            final KafkaSourceDataConverter dataConverter = new KafkaSourceDataConverter(serviceReader, conf, new ErrorExtractor());
+
+            log.info("Initializing source & sink for job");
+            final ISource kafkaSource = new KafkaSource(kafkaSourceConf, Optional.of(jsc), dataConverter, Optional.absent(), Optional.absent());
+
+            // Sink
+            HoodieSinkDataConverter hoodieSinkDataConverter = new CustomHoodieSinkDataConverter(conf, new ErrorExtractor());
+            HoodieSink hoodieSink = new HoodieSink(hoodieConf, hoodieSinkDataConverter, jsc, HoodieSink.HoodieSinkOp.INSERT, metadataManager, Optional.absent());
+
+            log.info("Initializing work unit calculator for job");
+            final IWorkUnitCalculator workUnitCalculator = new KafkaWorkUnitCalculator(kafkaSourceConf);
+
+            log.info("Initializing job dag");
+            final JobDag jobDag = new JobDag(kafkaSource, hoodieSink, metadataManager, workUnitCalculator,
+                    "test", "test", new JobMetrics("marmaray"), dataFeedMetrics,
+                    reporters);
+
+            jobManager.addJobDag(jobDag);
+
+            log.info("Running dispersal job");
+            try {
+                jobManager.run();
+                JobUtil.raiseExceptionIfStatusFailed(jobManager.getJobManagerStatus());
+            } catch (final Throwable t) {
+                if (TimeoutManager.getTimedOut()) {
+                    final LongMetric runTimeError = new LongMetric(DataFeedMetricNames.MARMARAY_JOB_ERROR, 1);
+                    runTimeError.addTags(metricTags);
+                    runTimeError.addTags(DataFeedMetricNames.getErrorModuleCauseTags(
+                            ModuleTagNames.JOB_MANAGER, ErrorCauseTagNames.TIME_OUT));
+                    reporters.report(runTimeError);
+                }
+                final LongMetric configError = new LongMetric(JobMetricNames.RUN_JOB_ERROR_COUNT, 1);
+                configError.addTags(metricTags);
+                reporters.report(configError);
+                throw t;
+            }
+            log.info("Dispersal job has been completed");
+
+            final TimerMetric jobLatencyMetric =
+                    new TimerMetric(JobMetricNames.RUN_JOB_DAG_LATENCY_MS, metricTags, jobStartTime);
+            jobLatencyMetric.stop();
+            reporters.report(jobLatencyMetric);
+            reporters.finish();
+        } finally {
+            jsc.stop();
+        }
+    }
+
+    /**
+     * Get configuration from command line
+     *
+     * @param args command line arguments passed in
+     * @return configuration populated from them
+     */
+    private Configuration getConfiguration(@NotEmpty final String[] args) {
+        final KafkaToHoodieCommandLineOptions options = new KafkaToHoodieCommandLineOptions(args);
+        if (options.getConfFile() != null) {
+            return getFileConfiguration(options.getConfFile());
+        } else if (options.getJsonConf() != null) {
+            return getJsonConfiguration(options.getJsonConf());
+        } else {
+            throw new JobRuntimeException("Unable to find conf; this shouldn't be possible");
+        }
+    }
+
+    /**
+     * Get configuration from JSON-based configuration
+     *
+     * @param jsonConf JSON string of configuration
+     * @return configuration populated from it
+     */
+    private Configuration getJsonConfiguration(@NotEmpty final String jsonConf) {
+        final Configuration conf = new Configuration();
+        conf.loadYamlStream(IOUtils.toInputStream(jsonConf), Optional.absent());
+        return conf;
+    }
+
+    /**
+     * Load configuration from a file on HDFS
+     *
+     * @param filePath path to the HDFS file to load
+     * @return configuration populated from it
+     */
+    private Configuration getFileConfiguration(@NotEmpty final String filePath) {
+        final Configuration conf = new Configuration();
+        try {
+            final FileSystem fs = FSUtils.getFs(conf, Optional.absent());
+            final Path dataFeedConfFile = new Path(filePath);
+            log.info("Loading configuration from {}", dataFeedConfFile.toString());
+            conf.loadYamlStream(fs.open(dataFeedConfFile), Optional.absent());
+        } catch (IOException e) {
+            final String errorMessage = String.format("Unable to find configuration for %s", filePath);
+            log.error(errorMessage);
+            throw new JobRuntimeException(errorMessage, e);
+        }
+        return conf;
+
+    }
+
+    /**
+     * Initialize the metadata store system
+     *
+     * @param conf configuration to use
+     * @param jsc  Java spark context
+     * @return metadata manager
+     */
+    private static IMetadataManager initMetadataManager(@NonNull final HoodieConfiguration conf, @NonNull final JavaSparkContext jsc) {
+        log.info("Create metadata manager");
+        try {
+            return new HoodieBasedMetadataManager(conf, new AtomicBoolean(true), jsc);
+        } catch (IOException e) {
+            throw new JobRuntimeException("Unable to create metadata manager", e);
+        }
+    }
+
+    private static final class KafkaToHoodieCommandLineOptions {
+        @Getter
+        @Parameter(names = {"--configurationFile", "-c"}, description = "path to configuration file")
+        private String confFile;
+
+        @Getter
+        @Parameter(names = {"--jsonConfiguration", "-j"}, description = "json configuration")
+        private String jsonConf;
+
+        private KafkaToHoodieCommandLineOptions(@NonNull final String[] args) {
+            final JCommander commander = new JCommander(this);
+            commander.parse(args);
+            Preconditions.checkState(this.confFile != null || this.jsonConf != null,
+                    "One of jsonConfiguration or configurationFile must be specified");
+        }
+    }
+
+}

--- a/marmaray/src/main/java/com/uber/marmaray/utilities/ErrorTableUtil.java
+++ b/marmaray/src/main/java/com/uber/marmaray/utilities/ErrorTableUtil.java
@@ -120,8 +120,7 @@ public final class ErrorTableUtil {
             final HoodieBasedMetadataManager metadataManager =
                 new HoodieBasedMetadataManager(hoodieConf, shouldSaveChanges, jsc);
             final HoodieSink hoodieSink = new HoodieErrorSink(hoodieConf, new DummyHoodieSinkDataConverter(), jsc,
-                                                                 HoodieSink.HoodieSinkOp.BULK_INSERT, metadataManager,
-                                                                 false);
+                    metadataManager,false);
 
             JavaRDD<GenericRecord> errorRecords = errorData.getData().map(error -> generateGenericErrorRecord(
                 errorExtractor, errorTableSchema, error, applicationId));

--- a/marmaray/src/test/java/com/uber/marmaray/common/sinks/hoodie/TestHoodieSink.java
+++ b/marmaray/src/test/java/com/uber/marmaray/common/sinks/hoodie/TestHoodieSink.java
@@ -156,11 +156,13 @@ public class TestHoodieSink extends AbstractSparkTest {
         final String basePath = FileTestUtil.getTempFolder();
         final String tableName = "test-table";
         final String schemaStr = getSchema(TS_KEY, RECORD_KEY, 4, 8).toString();
-        final HoodieSinkDataConverter hoodieKeyGenerator =
-            new TSBasedHoodieSinkDataConverter(conf, RECORD_KEY, TS_KEY, TimeUnit.MILLISECONDS);
         final HoodieConfiguration hoodieConf =
-            HoodieConfiguration.newBuilder(tableName).withTableName(tableName).withMetricsPrefix("test")
-                .withBasePath(basePath).withSchema(schemaStr).enableMetrics(false).build();
+                HoodieConfiguration.newBuilder(tableName).withTableName(tableName).withMetricsPrefix("test")
+                        .withBasePath(basePath).withSchema(schemaStr).withRecordKey(RECORD_KEY)
+                        .withPartitionPath(TS_KEY).enableMetrics(false).build();
+        final HoodieSinkDataConverter hoodieKeyGenerator =
+            new TSBasedHoodieSinkDataConverter(conf, hoodieConf, TimeUnit.MILLISECONDS);
+
         final MockHoodieSink hoodieSink = new MockHoodieSink(hoodieConf, hoodieKeyGenerator, jsc.get(), INSERT);
         final JavaRDD<AvroPayload> inputRDD =
             this.jsc.get().parallelize(getRandomData(schemaStr, TS_KEY, RECORD_KEY, 10));
@@ -201,11 +203,13 @@ public class TestHoodieSink extends AbstractSparkTest {
         final String basePath = FileTestUtil.getTempFolder();
         final String tableName = "test-table";
         final String schemaStr = getSchema(TS_KEY, RECORD_KEY, 4, 8).toString();
-        final HoodieSinkDataConverter hoodieKeyGenerator =
-            new TSBasedHoodieSinkDataConverter(this.conf, RECORD_KEY, TS_KEY, TimeUnit.MILLISECONDS);
         final HoodieConfiguration hoodieConf =
-            HoodieConfiguration.newBuilder(tableName).withTableName(tableName).withMetricsPrefix("test")
-                .withBasePath(basePath).withSchema(schemaStr).enableMetrics(false).build();
+                HoodieConfiguration.newBuilder(tableName).withTableName(tableName).withMetricsPrefix("test")
+                        .withBasePath(basePath).withSchema(schemaStr).withRecordKey(RECORD_KEY)
+                        .withPartitionPath(TS_KEY).enableMetrics(false).build();
+        final HoodieSinkDataConverter hoodieKeyGenerator =
+                new TSBasedHoodieSinkDataConverter(conf, hoodieConf, TimeUnit.MILLISECONDS);
+
         final MockHoodieSink hoodieSink = new MockHoodieSink(hoodieConf, hoodieKeyGenerator, jsc.get(), UPSERT);
         final JavaRDD<AvroPayload> inputRDD =
             this.jsc.get().parallelize(getRandomData(schemaStr, TS_KEY, RECORD_KEY, 10));
@@ -243,11 +247,12 @@ public class TestHoodieSink extends AbstractSparkTest {
         final String basePath = FileTestUtil.getTempFolder();
         final String tableName = "test-table";
         final String schemaStr = getSchema(TS_KEY, RECORD_KEY, 4, 8).toString();
-        final HoodieSinkDataConverter hoodieKeyGenerator =
-            new TSBasedHoodieSinkDataConverter(this.conf, RECORD_KEY, TS_KEY, TimeUnit.MILLISECONDS);
         final HoodieConfiguration hoodieConf =
-            HoodieConfiguration.newBuilder(tableName).withTableName(tableName).withMetricsPrefix("test")
-                .withBasePath(basePath).withSchema(schemaStr).enableMetrics(false).build();
+                HoodieConfiguration.newBuilder(tableName).withTableName(tableName).withMetricsPrefix("test")
+                        .withBasePath(basePath).withSchema(schemaStr).withRecordKey(RECORD_KEY)
+                        .withPartitionPath(TS_KEY).enableMetrics(false).build();
+        final HoodieSinkDataConverter hoodieKeyGenerator =
+                new TSBasedHoodieSinkDataConverter(conf, hoodieConf, TimeUnit.MILLISECONDS);
         final HoodieBasedMetadataManager hoodieBasedMetadataManager = new HoodieBasedMetadataManager(hoodieConf,
             new AtomicBoolean(true), this.jsc.get());
         hoodieBasedMetadataManager.set("randomKey", new StringValue("randomValue"));
@@ -291,11 +296,12 @@ public class TestHoodieSink extends AbstractSparkTest {
         final String basePath = FileTestUtil.getTempFolder();
         final String tableName = "test-table";
         final String schemaStr = getSchema(TS_KEY, RECORD_KEY, 4, 8).toString();
-        final HoodieSinkDataConverter hoodieKeyGenerator =
-            new TSBasedHoodieSinkDataConverter(this.conf, RECORD_KEY, TS_KEY, TimeUnit.MILLISECONDS);
         final HoodieConfiguration hoodieConf =
-            HoodieConfiguration.newBuilder(tableName).withTableName(tableName).withMetricsPrefix("test")
-                .withBasePath(basePath).withSchema(schemaStr).enableMetrics(false).build();
+                HoodieConfiguration.newBuilder(tableName).withTableName(tableName).withMetricsPrefix("test")
+                        .withBasePath(basePath).withSchema(schemaStr).withRecordKey(RECORD_KEY)
+                        .withPartitionPath(TS_KEY).enableMetrics(false).build();
+        final HoodieSinkDataConverter hoodieKeyGenerator =
+                new TSBasedHoodieSinkDataConverter(conf, hoodieConf, TimeUnit.MILLISECONDS);
         final HoodieBasedMetadataManager hoodieBasedMetadataManager = new HoodieBasedMetadataManager(hoodieConf,
             new AtomicBoolean(true), this.jsc.get());
         hoodieBasedMetadataManager.set("randomKey", new StringValue("randomValue"));
@@ -339,12 +345,13 @@ public class TestHoodieSink extends AbstractSparkTest {
         final String basePath = FileTestUtil.getTempFolder();
         final String tableName = "test-table";
         final String schemaStr = getSchema(TS_KEY, RECORD_KEY, 4, 8).toString();
-        final HoodieSinkDataConverter hoodieKeyGenerator =
-            new TSBasedHoodieSinkDataConverter(this.conf, RECORD_KEY, TS_KEY, TimeUnit.MILLISECONDS);
         final HoodieConfiguration hoodieConf =
-            HoodieConfiguration.newBuilder(tableName).withTableName(tableName).withMetricsPrefix("test")
-                .withBasePath(basePath).withSchema(schemaStr)
-                .withCombineBeforeInsert(true).withCombineBeforeUpsert(true).enableMetrics(false).build();
+                HoodieConfiguration.newBuilder(tableName).withTableName(tableName).withMetricsPrefix("test")
+                        .withBasePath(basePath).withSchema(schemaStr).withCombineBeforeInsert(true)
+                        .withCombineBeforeUpsert(true).withRecordKey(RECORD_KEY).withPartitionPath(TS_KEY)
+                        .enableMetrics(false).build();
+        final HoodieSinkDataConverter hoodieKeyGenerator =
+                new TSBasedHoodieSinkDataConverter(conf, hoodieConf, TimeUnit.MILLISECONDS);
         final JavaRDD<AvroPayload> inputRDD =
             this.jsc.get().parallelize(getRandomData(schemaStr, TS_KEY, RECORD_KEY, 10));
 
@@ -400,11 +407,14 @@ public class TestHoodieSink extends AbstractSparkTest {
         final String tableName = "test-table";
         final String schemaStr = getSchema(TS_KEY, RECORD_KEY, 4, 8).toString();
         final String brokenSchemaStr = getSchema(TS_KEY, RECORD_KEY, 0, 0).toString();
-        final HoodieSinkDataConverter hoodieKeyGenerator =
-                new TSBasedHoodieSinkDataConverter(conf, RECORD_KEY, TS_KEY, TimeUnit.MILLISECONDS);
+
         final HoodieConfiguration hoodieConf =
                 HoodieConfiguration.newBuilder(tableName).withTableName(tableName).withMetricsPrefix("test")
-                        .withBasePath(basePath).withSchema(schemaStr).enableMetrics(false).build();
+                        .withBasePath(basePath).withSchema(schemaStr).withRecordKey(RECORD_KEY)
+                        .withPartitionPath(TS_KEY).enableMetrics(false).build();
+        final HoodieSinkDataConverter hoodieKeyGenerator =
+                new TSBasedHoodieSinkDataConverter(conf, hoodieConf, TimeUnit.MILLISECONDS);
+
         final MockHoodieSink hoodieSink = new MockHoodieSink(hoodieConf, hoodieKeyGenerator, jsc.get(), INSERT);
         final Map<String, String> emptyTags = new HashMap<>();
         final DataFeedMetrics dfm = new DataFeedMetrics(JOB_NAME, emptyTags);
@@ -444,11 +454,14 @@ public class TestHoodieSink extends AbstractSparkTest {
         final String basePath = FileTestUtil.getTempFolder();
         final String tableName = "test-table";
         final String schemaStr = getSchema(TS_KEY, RECORD_KEY, 4, 8).toString();
-        final HoodieSinkDataConverter hoodieKeyGenerator =
-            new TSBasedHoodieSinkDataConverter(this.conf, RECORD_KEY, TS_KEY, TimeUnit.MILLISECONDS);
+
         final HoodieConfiguration hoodieConf =
-            HoodieConfiguration.newBuilder(tableName).withTableName(tableName).withMetricsPrefix("test")
-                .withBasePath(basePath).withSchema(schemaStr).enableMetrics(false).build();
+                HoodieConfiguration.newBuilder(tableName).withTableName(tableName).withMetricsPrefix("test")
+                        .withBasePath(basePath).withSchema(schemaStr).withRecordKey(RECORD_KEY)
+                        .withPartitionPath(TS_KEY).enableMetrics(false).build();
+        final HoodieSinkDataConverter hoodieKeyGenerator =
+                new TSBasedHoodieSinkDataConverter(conf, hoodieConf, TimeUnit.MILLISECONDS);
+
         final JavaRDD<AvroPayload> inputRDD =
             this.jsc.get().parallelize(getRandomData(schemaStr, TS_KEY, RECORD_KEY, 10));
 

--- a/marmaray/src/test/java/com/uber/marmaray/common/sinks/hoodie/TestHoodieSink.java
+++ b/marmaray/src/test/java/com/uber/marmaray/common/sinks/hoodie/TestHoodieSink.java
@@ -86,16 +86,14 @@ class MockHoodieSink extends HoodieSink {
     private HoodieWriteClientWrapper mockWriteClient;
 
     public MockHoodieSink(@NonNull final HoodieConfiguration hoodieConf,
-        @NonNull final HoodieSinkDataConverter hoodieKeyGenerator, @NonNull final JavaSparkContext jsc,
-        @NonNull final HoodieSinkOp op) {
-        super(hoodieConf, hoodieKeyGenerator, jsc, op, new MemoryMetadataManager(), Optional.absent());
+        @NonNull final HoodieSinkDataConverter hoodieKeyGenerator, @NonNull final JavaSparkContext jsc) {
+        super(hoodieConf, hoodieKeyGenerator, jsc, new MemoryMetadataManager(), Optional.absent());
     }
 
     public MockHoodieSink(@NonNull final HoodieConfiguration hoodieConf,
         @NonNull final HoodieSinkDataConverter hoodieKeyGenerator, @NonNull final JavaSparkContext jsc,
-        @NonNull final HoodieSinkOp op,
         @NonNull final IMetadataManager metadataMgr) {
-        super(hoodieConf, hoodieKeyGenerator, jsc, op, metadataMgr, Optional.absent());
+        super(hoodieConf, hoodieKeyGenerator, jsc, metadataMgr, Optional.absent());
     }
 
     @Override
@@ -122,11 +120,10 @@ public class TestHoodieSink extends AbstractSparkTest {
         final String schemaStr = getSchema("TS", "RECORD_KEY", 4, 8).toString();
         final HoodieConfiguration hoodieConf =
             HoodieConfiguration.newBuilder(tableName).withTableName(tableName).withMetricsPrefix("test")
-                .withBasePath(basePath).withSchema(schemaStr).enableMetrics(false).build();
+                .withBasePath(basePath).withSchema(schemaStr).withSinkOp("NO_OP").enableMetrics(false).build();
         final HoodieSink mockSink =
-            spy(new HoodieSink(hoodieConf, mock(HoodieSinkDataConverter.class),
-                mock(JavaSparkContext.class), HoodieSink.HoodieSinkOp.NO_OP, new NoOpMetadataManager(),
-                Optional.absent()));
+            spy(new HoodieSink(hoodieConf, mock(HoodieSinkDataConverter.class), mock(JavaSparkContext.class),
+                    new NoOpMetadataManager(), Optional.absent()));
         when(mockSink.calculateNewBulkInsertParallelism(anyLong())).thenReturn(18);
         Assert.assertTrue(mockSink.updateInsertParallelism(1000));
         Assert.assertEquals(18, hoodieConf.getInsertParallelism());
@@ -140,11 +137,10 @@ public class TestHoodieSink extends AbstractSparkTest {
         final String schemaStr = getSchema("TS", "RECORD_KEY", 4, 8).toString();
         final HoodieConfiguration hoodieConf =
             HoodieConfiguration.newBuilder(tableName).withTableName(tableName).withMetricsPrefix("test")
-                .withBasePath(basePath).withSchema(schemaStr).enableMetrics(false).build();
+                .withBasePath(basePath).withSchema(schemaStr).withSinkOp("NO_OP").enableMetrics(false).build();
         final HoodieSink mockSink =
-            spy(new HoodieSink(hoodieConf, mock(HoodieSinkDataConverter.class),
-                mock(JavaSparkContext.class), HoodieSink.HoodieSinkOp.NO_OP, new NoOpMetadataManager(),
-                Optional.absent()));
+            spy(new HoodieSink(hoodieConf, mock(HoodieSinkDataConverter.class), mock(JavaSparkContext.class),
+                    new NoOpMetadataManager(), Optional.absent()));
         when(mockSink.calculateNewBulkInsertParallelism(anyLong())).thenReturn(18);
         Assert.assertTrue(mockSink.updateBulkInsertParallelism(1000));
         Assert.assertEquals(18, hoodieConf.getBulkInsertParallelism());
@@ -159,11 +155,11 @@ public class TestHoodieSink extends AbstractSparkTest {
         final HoodieConfiguration hoodieConf =
                 HoodieConfiguration.newBuilder(tableName).withTableName(tableName).withMetricsPrefix("test")
                         .withBasePath(basePath).withSchema(schemaStr).withRecordKey(RECORD_KEY)
-                        .withPartitionPath(TS_KEY).enableMetrics(false).build();
+                        .withPartitionPath(TS_KEY).withSinkOp("INSERT").enableMetrics(false).build();
         final HoodieSinkDataConverter hoodieKeyGenerator =
             new TSBasedHoodieSinkDataConverter(conf, hoodieConf, TimeUnit.MILLISECONDS);
 
-        final MockHoodieSink hoodieSink = new MockHoodieSink(hoodieConf, hoodieKeyGenerator, jsc.get(), INSERT);
+        final MockHoodieSink hoodieSink = new MockHoodieSink(hoodieConf, hoodieKeyGenerator, jsc.get());
         final JavaRDD<AvroPayload> inputRDD =
             this.jsc.get().parallelize(getRandomData(schemaStr, TS_KEY, RECORD_KEY, 10));
         final Map<String, String> emptyTags = new HashMap<>();
@@ -206,11 +202,11 @@ public class TestHoodieSink extends AbstractSparkTest {
         final HoodieConfiguration hoodieConf =
                 HoodieConfiguration.newBuilder(tableName).withTableName(tableName).withMetricsPrefix("test")
                         .withBasePath(basePath).withSchema(schemaStr).withRecordKey(RECORD_KEY)
-                        .withPartitionPath(TS_KEY).enableMetrics(false).build();
+                        .withPartitionPath(TS_KEY).withSinkOp("UPSERT").enableMetrics(false).build();
         final HoodieSinkDataConverter hoodieKeyGenerator =
                 new TSBasedHoodieSinkDataConverter(conf, hoodieConf, TimeUnit.MILLISECONDS);
 
-        final MockHoodieSink hoodieSink = new MockHoodieSink(hoodieConf, hoodieKeyGenerator, jsc.get(), UPSERT);
+        final MockHoodieSink hoodieSink = new MockHoodieSink(hoodieConf, hoodieKeyGenerator, jsc.get());
         final JavaRDD<AvroPayload> inputRDD =
             this.jsc.get().parallelize(getRandomData(schemaStr, TS_KEY, RECORD_KEY, 10));
         final Map<String, String> emptyTags = new HashMap<>();
@@ -250,13 +246,13 @@ public class TestHoodieSink extends AbstractSparkTest {
         final HoodieConfiguration hoodieConf =
                 HoodieConfiguration.newBuilder(tableName).withTableName(tableName).withMetricsPrefix("test")
                         .withBasePath(basePath).withSchema(schemaStr).withRecordKey(RECORD_KEY)
-                        .withPartitionPath(TS_KEY).enableMetrics(false).build();
+                        .withPartitionPath(TS_KEY).withSinkOp("INSERT").enableMetrics(false).build();
         final HoodieSinkDataConverter hoodieKeyGenerator =
                 new TSBasedHoodieSinkDataConverter(conf, hoodieConf, TimeUnit.MILLISECONDS);
         final HoodieBasedMetadataManager hoodieBasedMetadataManager = new HoodieBasedMetadataManager(hoodieConf,
             new AtomicBoolean(true), this.jsc.get());
         hoodieBasedMetadataManager.set("randomKey", new StringValue("randomValue"));
-        final MockHoodieSink hoodieSink = new MockHoodieSink(hoodieConf, hoodieKeyGenerator, jsc.get(), INSERT,
+        final MockHoodieSink hoodieSink = new MockHoodieSink(hoodieConf, hoodieKeyGenerator, jsc.get(),
             hoodieBasedMetadataManager);
         final JavaRDD<AvroPayload> inputRDD =
             this.jsc.get().parallelize(getRandomData(schemaStr, TS_KEY, RECORD_KEY, 10));
@@ -299,13 +295,13 @@ public class TestHoodieSink extends AbstractSparkTest {
         final HoodieConfiguration hoodieConf =
                 HoodieConfiguration.newBuilder(tableName).withTableName(tableName).withMetricsPrefix("test")
                         .withBasePath(basePath).withSchema(schemaStr).withRecordKey(RECORD_KEY)
-                        .withPartitionPath(TS_KEY).enableMetrics(false).build();
+                        .withPartitionPath(TS_KEY).withSinkOp("UPSERT").enableMetrics(false).build();
         final HoodieSinkDataConverter hoodieKeyGenerator =
                 new TSBasedHoodieSinkDataConverter(conf, hoodieConf, TimeUnit.MILLISECONDS);
         final HoodieBasedMetadataManager hoodieBasedMetadataManager = new HoodieBasedMetadataManager(hoodieConf,
             new AtomicBoolean(true), this.jsc.get());
         hoodieBasedMetadataManager.set("randomKey", new StringValue("randomValue"));
-        final MockHoodieSink hoodieSink = new MockHoodieSink(hoodieConf, hoodieKeyGenerator, jsc.get(), UPSERT,
+        final MockHoodieSink hoodieSink = new MockHoodieSink(hoodieConf, hoodieKeyGenerator, jsc.get(),
             hoodieBasedMetadataManager);
 
         final JavaRDD<AvroPayload> inputRDD =
@@ -348,14 +344,14 @@ public class TestHoodieSink extends AbstractSparkTest {
         final HoodieConfiguration hoodieConf =
                 HoodieConfiguration.newBuilder(tableName).withTableName(tableName).withMetricsPrefix("test")
                         .withBasePath(basePath).withSchema(schemaStr).withCombineBeforeInsert(true)
-                        .withCombineBeforeUpsert(true).withRecordKey(RECORD_KEY).withPartitionPath(TS_KEY)
-                        .enableMetrics(false).build();
+                        .withCombineBeforeUpsert(true).withRecordKey(RECORD_KEY).withSinkOp("DEDUP_INSERT")
+                        .withPartitionPath(TS_KEY).enableMetrics(false).build();
         final HoodieSinkDataConverter hoodieKeyGenerator =
                 new TSBasedHoodieSinkDataConverter(conf, hoodieConf, TimeUnit.MILLISECONDS);
         final JavaRDD<AvroPayload> inputRDD =
             this.jsc.get().parallelize(getRandomData(schemaStr, TS_KEY, RECORD_KEY, 10));
 
-        final MockHoodieSink hoodieSink = new MockHoodieSink(hoodieConf, hoodieKeyGenerator, jsc.get(), DEDUP_INSERT);
+        final MockHoodieSink hoodieSink = new MockHoodieSink(hoodieConf, hoodieKeyGenerator, jsc.get());
         final Map<String, String> emptyTags = new HashMap<>();
         final DataFeedMetrics dfm = new DataFeedMetrics(JOB_NAME, emptyTags);
         hoodieSink.setDataFeedMetrics(dfm);
@@ -389,7 +385,7 @@ public class TestHoodieSink extends AbstractSparkTest {
 
         // If we try to re-insert then it should find all the records as a a part filterExists test and should not
         // call bulkInsert.
-        final MockHoodieSink hoodieSink2 = new MockHoodieSink(hoodieConf, hoodieKeyGenerator, jsc.get(), DEDUP_INSERT);
+        final MockHoodieSink hoodieSink2 = new MockHoodieSink(hoodieConf, hoodieKeyGenerator, jsc.get());
         hoodieSink.write(inputRDD);
         final HoodieWriteClientWrapper hoodieWriteClientWrapper2 = hoodieSink.getMockWriteClient();
 
@@ -411,11 +407,11 @@ public class TestHoodieSink extends AbstractSparkTest {
         final HoodieConfiguration hoodieConf =
                 HoodieConfiguration.newBuilder(tableName).withTableName(tableName).withMetricsPrefix("test")
                         .withBasePath(basePath).withSchema(schemaStr).withRecordKey(RECORD_KEY)
-                        .withPartitionPath(TS_KEY).enableMetrics(false).build();
+                        .withPartitionPath(TS_KEY).withSinkOp("INSERT").enableMetrics(false).build();
         final HoodieSinkDataConverter hoodieKeyGenerator =
                 new TSBasedHoodieSinkDataConverter(conf, hoodieConf, TimeUnit.MILLISECONDS);
 
-        final MockHoodieSink hoodieSink = new MockHoodieSink(hoodieConf, hoodieKeyGenerator, jsc.get(), INSERT);
+        final MockHoodieSink hoodieSink = new MockHoodieSink(hoodieConf, hoodieKeyGenerator, jsc.get());
         final Map<String, String> emptyTags = new HashMap<>();
         final DataFeedMetrics dfm = new DataFeedMetrics(JOB_NAME, emptyTags);
         hoodieSink.setDataFeedMetrics(dfm);
@@ -458,14 +454,14 @@ public class TestHoodieSink extends AbstractSparkTest {
         final HoodieConfiguration hoodieConf =
                 HoodieConfiguration.newBuilder(tableName).withTableName(tableName).withMetricsPrefix("test")
                         .withBasePath(basePath).withSchema(schemaStr).withRecordKey(RECORD_KEY)
-                        .withPartitionPath(TS_KEY).enableMetrics(false).build();
+                        .withPartitionPath(TS_KEY).withSinkOp("BULK_INSERT").enableMetrics(false).build();
         final HoodieSinkDataConverter hoodieKeyGenerator =
                 new TSBasedHoodieSinkDataConverter(conf, hoodieConf, TimeUnit.MILLISECONDS);
 
         final JavaRDD<AvroPayload> inputRDD =
             this.jsc.get().parallelize(getRandomData(schemaStr, TS_KEY, RECORD_KEY, 10));
 
-        final MockHoodieSink hoodieSink1 = new MockHoodieSink(hoodieConf, hoodieKeyGenerator, jsc.get(), BULK_INSERT);
+        final MockHoodieSink hoodieSink1 = new MockHoodieSink(hoodieConf, hoodieKeyGenerator, jsc.get());
         final Map<String, String> emptyTags = new HashMap<>();
         final DataFeedMetrics dfm = new DataFeedMetrics(JOB_NAME, emptyTags);
         hoodieSink1.setDataFeedMetrics(dfm);
@@ -481,7 +477,7 @@ public class TestHoodieSink extends AbstractSparkTest {
             HoodieActiveTimeline.COMMIT_FORMATTER.format(
                 new Date(new Date().getTime() - TimeUnit.DAYS.toMillis(365)));
 
-        final MockHoodieSink hoodieSink2 = new MockHoodieSink(hoodieConf, hoodieKeyGenerator, jsc.get(), BULK_INSERT);
+        final MockHoodieSink hoodieSink2 = new MockHoodieSink(hoodieConf, hoodieKeyGenerator, jsc.get());
         hoodieSink2.setDataFeedMetrics(dfm);
         hoodieSink2.setCommitTime(com.google.common.base.Optional.of(customCommit));
 


### PR DESCRIPTION
- Add an example job that reads from Kafka and writes to Hoodie
- Add `KafkaSchemaServiceReader` abstract classes
- Add `record_key`, `partition_path` and `sink_op` configuration support through the configuration file
- Fix bug for edge case when the Job starts reading from Kafka's initial offset. The older code just exited without performing any tasks